### PR TITLE
Fix type definitions for moduleResolution nodenext

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
 	"main": "./dist/property-graph.cjs",
 	"module": "./dist/property-graph.esm.js",
 	"exports": {
+		"types": "./dist/index.d.ts",
 		"require": "./dist/property-graph.cjs",
 		"default": "./dist/property-graph.modern.js"
 	},

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
-import type { GraphEdge } from './graph-edge';
-import type { GraphNode } from './graph-node';
+import type { GraphEdge } from './graph-edge.js';
+import type { GraphNode } from './graph-node.js';
 
 /** TypeScript utility for nullable types. */
 export type Nullable<T> = { [P in keyof T]: T[P] | null };

--- a/src/event-dispatcher.ts
+++ b/src/event-dispatcher.ts
@@ -1,6 +1,6 @@
-import type { Graph } from './graph';
-import type { GraphNode } from './graph-node';
-import type { GraphEdge } from './graph-edge';
+import type { Graph } from './graph.js';
+import type { GraphNode } from './graph-node.js';
+import type { GraphEdge } from './graph-edge.js';
 
 export interface BaseEvent {
 	type: string;

--- a/src/graph-edge.ts
+++ b/src/graph-edge.ts
@@ -1,5 +1,5 @@
-import { EventDispatcher, GraphEdgeEvent } from './event-dispatcher';
-import { GraphNode } from './graph-node';
+import { EventDispatcher, GraphEdgeEvent } from './event-dispatcher.js';
+import { GraphNode } from './graph-node.js';
 
 /**
  * Represents a connection between two {@link GraphNode} resources in a {@link Graph}.

--- a/src/graph-node.ts
+++ b/src/graph-node.ts
@@ -1,11 +1,10 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/ban-types */
-import { GraphNodeEvent } from '.';
-import { LiteralKeys, Nullable, Ref, RefMap, RefKeys, RefListKeys, RefMapKeys } from './constants';
-import { BaseEvent, EventDispatcher } from './event-dispatcher';
-import { Graph } from './graph';
-import { GraphEdge } from './graph-edge';
-import { isRef, isRefList, isRefMap } from './utils';
+import { LiteralKeys, Nullable, Ref, RefMap, RefKeys, RefListKeys, RefMapKeys } from './constants.js';
+import { BaseEvent, EventDispatcher, GraphNodeEvent } from './event-dispatcher.js';
+import { Graph } from './graph.js';
+import { GraphEdge } from './graph-edge.js';
+import { isRef, isRefList, isRefMap } from './utils.js';
 
 // References:
 // - https://stackoverflow.com/a/70163679/1314762

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -1,7 +1,6 @@
-import { GraphNodeEvent } from '.';
-import { EventDispatcher, GraphEdgeEvent, GraphEvent } from './event-dispatcher';
-import { GraphEdge } from './graph-edge';
-import { GraphNode } from './graph-node';
+import { EventDispatcher, GraphEdgeEvent, GraphEvent, GraphNodeEvent } from './event-dispatcher.js';
+import { GraphEdge } from './graph-edge.js';
+import { GraphNode } from './graph-node.js';
 
 /**
  * A graph manages a network of {@link GraphNode} nodes, connected

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-export * from './constants'; // required for type inference
-export * from './event-dispatcher';
-export * from './graph';
-export * from './graph-node';
-export * from './graph-edge';
-export * from './utils';
+export * from './constants.js'; // required for type inference
+export * from './event-dispatcher.js';
+export * from './graph.js';
+export * from './graph-node.js';
+export * from './graph-edge.js';
+export * from './utils.js';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
-import type { Ref, RefMap } from './constants';
-import { GraphEdge } from './graph-edge';
+import type { Ref, RefMap } from './constants.js';
+import { GraphEdge } from './graph-edge.js';
 
 export function isRef(value: Ref | unknown): boolean {
 	return value instanceof GraphEdge;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
 		"paths": {
 			"property-graph": ["./"]
 		},
-		"moduleResolution": "node",
+		"moduleResolution": "nodenext",
 		"lib": ["es2020", "dom"],
 		"target": "es2020",
 		"module": "es2020",


### PR DESCRIPTION
When importing this library in a project using moduleResolution nodenext, the types would give errors because the import paths were missing the file extension which is required for moduleResolution nodenext. Therefore we have to add .js to all imports of local files.

See https://github.com/developit/microbundle/issues/1019#issuecomment-1384721680 and the issues that comment links to for some more detailed explanation of this.

I also changed moduleResolution to nodenext in the tsconfig because when it's set to node, typescript won't give errors for missing file extensions which means they are easy to forget. With it set to nodenext, you will get an error if an import is missing the file extension. As far as I can see, changing this doesn't change the build output.