### PR TITLE
Speed up isRefMap

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -10,5 +10,15 @@ export function isRefList(value: Ref[] | unknown): boolean {
 }
 
 export function isRefMap(value: RefMap | unknown): boolean {
-	return !!(value && typeof value === 'object' && Object.values(value)[0] instanceof GraphEdge);
+	return !!(isPlainObject(value) && getFirstValue(value) instanceof GraphEdge);
+}
+
+function getFirstValue(value: Record<string, unknown>): unknown {
+	for (const key in value) {
+		return value[key];
+	}
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return Boolean(value) && Object.getPrototypeOf(value) === Object.prototype;
 }


### PR DESCRIPTION
Hey, I was using gltf-transform and noticed the isRefMap function was taking a lot of time (85% of my merge call), which led me here.

![image](https://user-images.githubusercontent.com/92771507/231019639-7f1a5ebc-6703-4e34-9dbd-2d0ea6e291cf.png)

The current implementation was calling `Object.values(value)[0]`, creating an entire array when we only need the first value. I created the `getFirstValue` function, which will take the same amount of time no matter the object size, greatly improving speed when working with objects with many keys.

I also noticed the function was checking the first value of arrays and TypedArrays, which from my understanding is not needed, as we only need to check plain objects. I created the `isPlainObject` function to filter these out, which also brought some performance gains.

After these changes the merge call saw a 10x increase in speed, dropping from 90ms to 10ms.

![image](https://user-images.githubusercontent.com/92771507/231019570-ee8a05da-a716-4f63-942f-73a5054283a4.png)
