### PR TITLE
GraphNode: Improve performance of node disposal in large ref lists

### DIFF
--- a/src/graph-node.ts
+++ b/src/graph-node.ts
@@ -242,9 +242,10 @@ export abstract class GraphNode<Attributes extends {} = {}> extends EventDispatc
 		refs.push(ref);
 
 		ref.addEventListener('dispose', () => {
-			const retained = refs.filter((l) => l !== ref);
-			refs.length = 0;
-			for (const retainedRef of retained) refs.push(retainedRef);
+			let index;
+			while ((index = refs.indexOf(ref)) !== -1) {
+				refs.splice(index, 1);
+			}
 			this.dispatchEvent({ type: 'change', attribute });
 		});
 


### PR DESCRIPTION
More optimization could be done here, but I'm concerned that complex behavior changes (batch disposal, lazy cleanup, etc.) could have more side effects and maintenance requirements than I'm prepared to deal with.

In glTF Transform v4, I'm tempted to use Sets for RefLists, which should help here dramatically, but that is a breaking change to APIs, and doesn't justify a major release right now.

This change is simple enough, and improves performance dramatically when disposing of items in large reference lists. On quick benchmarks, this was a 5x performance improvement for a list containing 30,000 items.

Related:

- Fixes #83 
- Related https://github.com/donmccurdy/property-graph/pull/44
- Related https://github.com/donmccurdy/property-graph/issues/20
- Related https://github.com/donmccurdy/glTF-Transform/discussions/520