### PR TITLE
fix(graph): Remove duplicates from graph.listParents() results

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -25,7 +25,11 @@ export class Graph<T extends GraphNode> extends EventDispatcher<GraphEvent | Gra
 
 	/** Returns a list of parent nodes for the given child node. */
 	public listParents(node: T): T[] {
-		return this.listParentEdges(node).map((edge) => edge.getParent());
+		const parentSet = new Set<T>();
+		for (const edge of this.listParentEdges(node)) {
+			parentSet.add(edge.getParent());
+		}
+		return Array.from(parentSet);
 	}
 
 	/** Returns a list of all edges on the graph having the given node as their parent. */
@@ -57,7 +61,7 @@ export class Graph<T extends GraphNode> extends EventDispatcher<GraphEvent | Gra
 		name: string,
 		a: A,
 		b: B,
-		attributes?: Record<string, unknown>
+		attributes?: Record<string, unknown>,
 	): GraphEdge<A, B> {
 		return this._registerEdge(new GraphEdge(name, a, b, attributes)) as GraphEdge<A, B>;
 	}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -228,3 +228,37 @@ test('property-graph::graph-node | swap', (t) => {
 	t.deepEqual(listLabels(graph.listParentEdges(a)), [], 'removed old edge');
 	t.deepEqual(listLabels(graph.listParentEdges(b)), [{ label: 'custom-label' }], 'persist attributes');
 });
+
+test('property-graph::graph | listParents', (t) => {
+	const graph = new Graph();
+	const root = new Person(graph).setName('root');
+	const a = new Person(graph).setName('a');
+	const b = new Person(graph).setName('b');
+	const c = new Person(graph).setName('c');
+
+	root.addFriend(a);
+	root.addFriend(b);
+	root.addFriend(c);
+
+	a.addFriend(b);
+	b.addFriend(c);
+
+	a.addRecentCall(b);
+
+	t.deepEqual(
+		graph.listParents(root).map((n) => (n as Person).getName()),
+		[],
+	);
+	t.deepEqual(
+		graph.listParents(a).map((n) => (n as Person).getName()),
+		['root'],
+	);
+	t.deepEqual(
+		graph.listParents(b).map((n) => (n as Person).getName()),
+		['root', 'a'],
+	);
+	t.deepEqual(
+		graph.listParents(c).map((n) => (n as Person).getName()),
+		['root', 'b'],
+	);
+});


### PR DESCRIPTION
Results of `graph.listParents()` should not list the same parent twice, regardless of how many edges connect the parent to the child.

Related:

- https://github.com/donmccurdy/glTF-Transform/issues/1537