### PR TITLE
fix(graph): Remove duplicates from graph.listChildren() results

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -39,7 +39,11 @@ export class Graph<T extends GraphNode> extends EventDispatcher<GraphEvent | Gra
 
 	/** Returns a list of child nodes for the given parent node. */
 	public listChildren(node: T): T[] {
-		return this.listChildEdges(node).map((edge) => edge.getChild());
+		const childSet = new Set<T>();
+		for (const edge of this.listChildEdges(node)) {
+			childSet.add(edge.getChild());
+		}
+		return Array.from(childSet);
 	}
 
 	public disconnectParents(node: T, filter?: (n: T) => boolean): this {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -262,3 +262,37 @@ test('property-graph::graph | listParents', (t) => {
 		['root', 'b'],
 	);
 });
+
+test('property-graph::graph | listChildren', (t) => {
+	const graph = new Graph();
+	const root = new Person(graph).setName('root');
+	const a = new Person(graph).setName('a');
+	const b = new Person(graph).setName('b');
+	const c = new Person(graph).setName('c');
+
+	root.addFriend(a);
+	root.addFriend(b);
+	root.addFriend(c);
+
+	a.addFriend(b);
+	b.addFriend(c);
+
+	a.addRecentCall(b);
+
+	t.deepEqual(
+		graph.listChildren(root).map((n) => (n as Person).getName()),
+		['a', 'b', 'c'],
+	);
+	t.deepEqual(
+		graph.listChildren(a).map((n) => (n as Person).getName()),
+		['b'],
+	);
+	t.deepEqual(
+		graph.listChildren(b).map((n) => (n as Person).getName()),
+		['c'],
+	);
+	t.deepEqual(
+		graph.listChildren(c).map((n) => (n as Person).getName()),
+		[],
+	);
+});


### PR DESCRIPTION
See:

- #171