### PR TITLE
refactor(EventDispatcher): Make ._listeners non-nullable

### DIFF
--- a/src/event-dispatcher.ts
+++ b/src/event-dispatcher.ts
@@ -22,7 +22,7 @@ export interface GraphEdgeEvent extends BaseEvent {
 export type EventListener<E> = (event: E) => void;
 
 export class EventDispatcher<T extends BaseEvent> {
-	private _listeners = {} as Record<string, EventListener<T>[]>;
+	private _listeners: Record<string, EventListener<T>[]> = {};
 
 	addEventListener(type: string, listener: EventListener<T>): this {
 		const listeners = this._listeners;
@@ -39,8 +39,6 @@ export class EventDispatcher<T extends BaseEvent> {
 	}
 
 	removeEventListener(type: string, listener: EventListener<T>): this {
-		if (this._listeners === undefined) return this;
-
 		const listeners = this._listeners;
 		const listenerArray = listeners[type];
 
@@ -56,8 +54,6 @@ export class EventDispatcher<T extends BaseEvent> {
 	}
 
 	dispatchEvent(event: T): this {
-		if (this._listeners === undefined) return this;
-
 		const listeners = this._listeners;
 		const listenerArray = listeners[event.type];
 


### PR DESCRIPTION
I suppose I had some intention of initializing `._listeners` as null or undefined originally, and allocating it lazily, but only implemented the null checks and never actually initialized to null. In retrospect I think I'd prefer for the object to be monomorphic, and to have the ._listeners property unconditionally.